### PR TITLE
Add Inject parameter decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,68 @@ injector.register(asValue('PI', Math.PI));
 const pi = injector.resolve('PI');
 ```
 
+### Providing a non-class value as a constructor parameter
+```ts
+import { Resolvable, Inject } from '@archware/di';
+import { asValue } from '@archware/di/register';
+
+// 1. Use asValue to correlate some arbitrary token to a value
+injector.register(asValue('NAME', 'John'));
+
+@Resolvable()
+class Person {
+  constructor(
+    // 2. Pass the token to @Inject()
+    @Inject('NAME') public name: string,
+  ) { }
+}
+
+const person = injector.resolve(Person); // person.name will be 'John'
+```
+
+### Overriding an interface implementation
+```ts
+import { Resolvable, Inject } from '@archware/di';
+import { asImplementation } from '@archware/di/register';
+
+interface Engine {
+  start(): void;
+}
+abstract class Engine { }
+
+@Resolvable()
+class V8Engine implements Engine {
+  start() { }
+}
+
+@Resolvable()
+class ElectricEngine implements Engine {
+  start() { }
+}
+
+@Resolvable()
+class Car {
+  constructor(engine: Engine) { }
+}
+
+@Resolvable()
+class SportsCar {
+  constructor(
+    // 1. Provide the chosen implementation to @Inject() decorator
+    @Inject(V8Engine) engine: Engine
+  ) { }
+}
+
+// This will be overriden by @Inject()
+injector.register(asImplementation(Engine, ElectricEngine));
+
+// 2. Get the car with V8Engine
+injector.resolve(SportsCar);
+
+// This will still return a Car with ElectricEngine
+injector.resolve(Car);
+```
+
 ## Support
 We encourage you to create an issue if you want to:
 - raise a bug

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@archware/di",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archware/di",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Lightweight dependency injection for TypeScript",
   "main": "index.js",
   "scripts": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -74,7 +74,7 @@ describe("Injector", () => {
   });
 
   describe("@Inject", () => {
-    test("override paramtypes", () => {
+    test("override inferred parameters", () => {
       // given
       const injector = new Injector();
 
@@ -110,10 +110,12 @@ describe("Injector", () => {
       @Resolvable()
       class Person {
         constructor(
+          // when
           @Inject("NAME") public name: string,
         ) { }
       }
 
+      // then
       expect(injector.resolve(Person).name).toStrictEqual("John");
     });
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { Injector, Resolvable } from './index';
+import { Injector, Resolvable, Inject } from './index';
 import { asValue, asImplementation, asClass } from './register';
 
 describe("Injector", () => {
@@ -71,6 +71,51 @@ describe("Injector", () => {
 
     // then
     expect(injector.resolve(Pet)).toBeInstanceOf(Dog);
+  });
+
+  describe("@Inject", () => {
+    test("override paramtypes", () => {
+      // given
+      const injector = new Injector();
+
+      interface Engine { }
+      abstract class Engine { }
+
+      @Resolvable()
+      class ElectricEngine implements Engine { }
+
+      @Resolvable()
+      class V8Engine implements Engine { }
+
+      @Resolvable()
+      class Car {
+        constructor(
+          // when
+          @Inject(V8Engine) public engine: Engine
+        ) { }
+      }
+
+      injector.register(asImplementation(Engine, ElectricEngine));
+
+      // then
+      expect(injector.resolve(Car).engine).toBeInstanceOf(V8Engine);
+    });
+
+    test("couple with asValue() to provide arbitrary type", () => {
+      // given
+      const injector = new Injector();
+
+      injector.register(asValue("NAME", "John"));
+
+      @Resolvable()
+      class Person {
+        constructor(
+          @Inject("NAME") public name: string,
+        ) { }
+      }
+
+      expect(injector.resolve(Person).name).toStrictEqual("John");
+    });
   });
 
   describe("singletons", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Injector } from './lib/Injector';
 export { Resolvable } from './lib/Resolvable';
+export { Inject } from './lib/Inject';

--- a/src/lib/Inject.ts
+++ b/src/lib/Inject.ts
@@ -1,0 +1,19 @@
+const INJECT = Symbol("INJECT");
+
+export const setInject = (target: any, index: number, token: any) => {
+  const inject = mustGetInject(target);
+
+  inject.set(index, token);
+
+  target[INJECT] = inject;
+}
+
+export const mustGetInject = (target: any): Map<number, any> => {
+  return target[INJECT] ?? new Map();
+}
+
+export const Inject = (token: any): ParameterDecorator => (
+  (target, propertyKey, parameterIndex) => {
+    setInject(target, parameterIndex, token);
+  }
+)

--- a/src/lib/asClass.ts
+++ b/src/lib/asClass.ts
@@ -1,12 +1,12 @@
 import { Registrable } from './Registrable';
-import { mustGetParamtypes } from './Paramtypes';
 import { getOptions } from './ResolvableOptions';
+import { getClassDependencies } from './getClassDependencies';
 
 export const asClass = <T>(Target: new (...args: any[]) => T): Registrable<T> => {
   return {
     token: Target,
     descriptor: {
-      dependencies: mustGetParamtypes(Target),
+      dependencies: getClassDependencies(Target),
       factory: (...args: ConstructorParameters<typeof Target>) => new Target(...args),
       isSingleton: getOptions(Target)?.singleton ?? false,
     },

--- a/src/lib/asImplementation.ts
+++ b/src/lib/asImplementation.ts
@@ -1,6 +1,6 @@
 import { Registrable } from './Registrable';
-import { mustGetParamtypes } from './Paramtypes';
 import { getOptions } from './ResolvableOptions';
+import { getClassDependencies } from './getClassDependencies';
 
 export const asImplementation = <T>(
   InterfaceClass: abstract new (...args: any[]) => T,
@@ -10,7 +10,7 @@ export const asImplementation = <T>(
     token: InterfaceClass,
     descriptor: {
       factory: (...args: ConstructorParameters<typeof ImplementationClass>) => new ImplementationClass(...args),
-      dependencies: mustGetParamtypes(ImplementationClass),
+      dependencies: getClassDependencies(ImplementationClass),
       isSingleton: getOptions(ImplementationClass)?.singleton ?? false,
     },
   };

--- a/src/lib/getClassDependencies.ts
+++ b/src/lib/getClassDependencies.ts
@@ -1,0 +1,11 @@
+import { mustGetParamtypes } from './Paramtypes';
+import { mustGetInject } from './Inject';
+
+export const getClassDependencies = (Target: any) => {
+  const paramtypes = mustGetParamtypes(Target);
+  const inject = mustGetInject(Target);
+
+  return paramtypes.map(((value, index) => {
+    return inject.get(index) ?? value;
+  }));
+}


### PR DESCRIPTION
### Abstract
This adds `@Inject()` parameter decorator.

There are two supported usecases:
1. Decorate the parameter as `@Inject(AlternativeImplementation)` to override previously defined `asImplementation(SomeInterface, DefaultImplementation)` registration
2. Decorate the parameter as `@Inject(<any arbitrary value>)` and pair with `asValue(<any arbitrary value>, theValue)` to provide a leeway for dealing with non-runtime objects or misalignment between parameter type and token.

### Tasks
- [x] Add README example