### PR TITLE
Fail register if registering the same token twice

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -116,4 +116,17 @@ describe("Injector", () => {
       expect(instanceCreated).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("register", () => {
+    test("fail to register the same token twice", () => {
+      // given
+      const injector = new Injector();
+
+      // when
+      injector.register(asValue("PI", Math.PI));
+
+      // then
+      expect(() => injector.register(asValue("PI", Math.PI))).toThrowError();
+    });
+  });
 });

--- a/src/lib/Injector.ts
+++ b/src/lib/Injector.ts
@@ -6,6 +6,12 @@ export class Injector {
   constructor(private registry = new Map<any, Descriptor<any>>(), private container = new Map<any, any>()) {}
 
   public register({ token, descriptor }: Registrable<any>) {
+    if (this.registry.has(token)) {
+      throw new Error(`
+        ${token.prototype?.constructor?.name ?? token} has already been registered.
+      `);
+    }
+
     this.registry.set(token, descriptor);
   }
 


### PR DESCRIPTION
### Abstract
This ensures an error is thrown when attempting to register the same token twice.

Because Injector is designed to be instantiated once per certain dependency tree, being able to change the internal state of injector is against the designed behaviour and would cause hard to debug runtime issues.